### PR TITLE
➕(core) replace json schema validation with pydantic model

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,12 +36,14 @@ jobs:
       - run:
           name: Install gitlint
           command: |
-            pip install --user .[gitlint]
-          working_directory: src/marion
+            python -m venv venv
+            source venv/bin/activate && \
+              pip install gitlint requests
       - run:
           name: lint commit messages added to master
           command: |
-            ~/.local/bin/gitlint --commits origin/master..HEAD
+            source venv/bin/activate &&
+              gitlint --commits origin/master..HEAD
 
   # Check that the CHANGELOG has been updated in the current branch
   check-changelog:

--- a/src/howard/howard/issuers/__init__.py
+++ b/src/howard/howard/issuers/__init__.py
@@ -1,3 +1,1 @@
 """Issuer shortcuts for the howard application"""
-
-from .realisation import RealisationCertificate  # noqa: F401

--- a/src/howard/howard/templates/marion/certificates/realisation.html
+++ b/src/howard/howard/templates/marion/certificates/realisation.html
@@ -63,8 +63,8 @@
           </div>
           <div class="dates">
             qui s'est déroulée du
-            <span>{{ course.session.date.from }}</span> au
-            <span>{{ course.session.date.to }} </span>
+            <span>{{ course.session.datespan.start | date:"d/m/Y" }}</span> au
+            <span>{{ course.session.datespan.end | date:"d/m/Y" }} </span>
           </div>
           <div class="duration">
             pour une durée totale de <span>{{ course.session.duration }}</span> heures.
@@ -87,7 +87,7 @@
               Fait à : <span>{{ course.organization.location }}</span>
             </div>
             <div class="date">
-              Le : <span>{{ creation_date }}</span>
+              Le : <span>{{ creation_date | date:"d/m/Y" }}</span>
             </div>
           </div>
           <div class="seal">

--- a/src/howard/howard/tests/issuers/test_realisation.py
+++ b/src/howard/howard/tests/issuers/test_realisation.py
@@ -1,41 +1,680 @@
 """Tests for the howard.issuers.realisation application views"""
 
 import uuid
-from datetime import datetime
+from datetime import date, datetime
 
 from django.template import Context
 
-from howard.issuers import RealisationCertificate
+import pytest
+from howard.issuers.realisation import (
+    ArrowDate,
+    CertificateScope,
+    ContextModel,
+    ContextQueryModel,
+    Course,
+    DateSpan,
+    Gender,
+    Manager,
+    Organization,
+    RealisationCertificate,
+    Session,
+    Student,
+)
+from pydantic.error_wrappers import ValidationError
 
 
-def test_realisation_certificate_fetch_context(monkeypatch):
-    """Test Realisation Certificate fetch_context"""
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"start": ArrowDate("2021/01/01"), "end": ArrowDate("2021/12/31")},
+        {"start": ArrowDate(1609459200), "end": ArrowDate(1640908800)},
+        {"start": ArrowDate(date(2021, 1, 1)), "end": ArrowDate(date(2021, 12, 31))},
+    ],
+)
+def test_datespan_model_with_valid_content(kwargs):
+    """Tests a valid DateSpan model does not raise ValidationError."""
 
-    class TestCertificate(RealisationCertificate):
-        pass
+    try:
+        DateSpan(**kwargs)
+    except ValidationError:
+        pytest.fail(f"Valid DateSpan model with {kwargs} should not raise exceptions.")
 
-    identifier = uuid.uuid4()
-    test_certificate = TestCertificate(identifier=identifier)
 
-    freezed_now = datetime(2021, 1, 1, 0, 0, 0)
-    monkeypatch.setattr("django.utils.timezone.now", lambda: freezed_now)
+@pytest.mark.parametrize(
+    "kwargs, error",
+    [
+        (
+            {"start": None, "end": ArrowDate("31-12-2021")},
+            "start\n  none is not an allowed value",
+        ),
+        (
+            {"start": ArrowDate("31-12-2021"), "end": None},
+            "end\n  none is not an allowed value",
+        ),
+        (
+            {"start": "01-01-2021", "end": ArrowDate("31-12-2021")},
+            "start\n  Invalid value",
+        ),
+        (
+            {"start": ArrowDate("01-01-2021"), "end": "31-12-2021"},
+            "end\n  Invalid value",
+        ),
+        ({"start": 1609459200, "end": ArrowDate(1640908800)}, "start\n  Invalid value"),
+        ({"start": ArrowDate(1609459200), "end": 1640908800}, "end\n  Invalid value"),
+        (
+            {"start": date(2021, 1, 1), "end": ArrowDate(date(2021, 12, 31))},
+            "start\n  Invalid value",
+        ),
+        (
+            {"start": ArrowDate(date(2021, 1, 1)), "end": date(2021, 12, 31)},
+            "end\n  Invalid value",
+        ),
+        (
+            {"start": ArrowDate("foo"), "end": ArrowDate(date(2021, 12, 31))},
+            "start\n  Could not match input 'foo'",
+        ),
+        (
+            {"start": ArrowDate(date(2021, 1, 1)), "end": ArrowDate("foo")},
+            "end\n  Could not match input 'foo'",
+        ),
+        (
+            {"start": ArrowDate(True), "end": ArrowDate(date(2021, 1, 1))},
+            "start\n  Cannot parse single argument of type <class 'bool'>.",
+        ),
+        (
+            {"start": ArrowDate(date(2021, 1, 1)), "end": ArrowDate(True)},
+            "end\n  Cannot parse single argument of type <class 'bool'>.",
+        ),
+        (
+            {"end": ArrowDate("2021/12/31")},
+            "start\n  field required",
+        ),
+        (
+            {"start": ArrowDate("2021/01/01")},
+            "end\n  field required",
+        ),
+    ],
+)
+def test_datespan_model_with_invalid_content(kwargs, error):
+    """Tests a invalid DateSpan model raises a ValidationError."""
 
-    expected = Context(
+    with pytest.raises(ValidationError, match=error):
+        DateSpan(**kwargs)
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"first_name": "John", "last_name": "Doe", "position": "CEO"},
+        {"first_name": "Jane", "last_name": "Doe", "position": "CTO"},
+    ],
+)
+def test_manager_model_with_valid_content(kwargs):
+    """Tests a valid Manager model does not raise ValidationError."""
+
+    try:
+        Manager(**kwargs)
+    except ValidationError:
+        pytest.fail(f"Valid Manager model with {kwargs} should not raise exceptions.")
+
+
+@pytest.mark.parametrize(
+    "kwargs, error",
+    [
+        (
+            {"first_name": None, "last_name": "Doe", "position": "CEO"},
+            "first_name\n  none is not an allowed value",
+        ),
+        (
+            {"first_name": "Jane", "last_name": None, "position": "CEO"},
+            "last_name\n  none is not an allowed value",
+        ),
+        (
+            {"first_name": "Jane", "last_name": "Doe", "position": None},
+            "position\n  none is not an allowed value",
+        ),
+        (
+            {"last_name": "Doe", "position": "CEO"},
+            "first_name\n  field required",
+        ),
+        (
+            {"first_name": "Jane", "position": "CEO"},
+            "last_name\n  field required",
+        ),
+        (
+            {"first_name": "Jane", "last_name": "Doe"},
+            "position\n  field required",
+        ),
+    ],
+)
+def test_manager_model_with_invalid_content(kwargs, error):
+    """Tests a invalid Manager model raises a ValidationError."""
+
+    with pytest.raises(ValidationError, match=error):
+        Manager(**kwargs)
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
         {
-            "identifier": str(identifier),
+            "name": "edx",
+            "manager": {
+                "position": "CEO",
+                "last_name": "Agarwal",
+                "first_name": "Anant",
+            },
+            "location": "Boston, MA",
+        },
+        {
+            "name": "edx",
+            "location": "Boston, MA",
+        },
+        {
+            "name": "edx",
+            "manager": {
+                "position": "CEO",
+                "last_name": "Agarwal",
+                "first_name": "Anant",
+            },
+        },
+    ],
+)
+def test_organization_model_with_valid_content(kwargs):
+    """Tests a valid Organization model does not raise ValidationError."""
+
+    try:
+        Organization(**kwargs)
+    except ValidationError:
+        pytest.fail(
+            f"Valid Organization model with {kwargs} should not raise exceptions."
+        )
+
+
+@pytest.mark.parametrize(
+    "kwargs, error",
+    [
+        (
+            {
+                "name": None,
+                "manager": {
+                    "position": "CEO",
+                    "last_name": "Agarwal",
+                    "first_name": "Anant",
+                },
+                "location": "Boston, MA",
+            },
+            "name\n  none is not an allowed value",
+        ),
+        (
+            {
+                "name": "edx",
+                "manager": "CEO, Agarwal Anant",
+                "location": "Boston, MA",
+            },
+            "manager\n  value is not a valid dict",
+        ),
+        (
+            {
+                "manager": {
+                    "position": "CEO",
+                    "last_name": "Agarwal",
+                    "first_name": "Anant",
+                },
+                "location": "Boston, MA",
+            },
+            "name\n  field required",
+        ),
+    ],
+)
+def test_organization_model_with_invalid_content(kwargs, error):
+    """Tests a invalid Organization model raises a ValidationError."""
+
+    with pytest.raises(ValidationError, match=error):
+        Organization(**kwargs)
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {
+            "first_name": "John",
+            "last_name": "Doe",
+            "gender": Gender.MALE,
+            "organization": {
+                "name": "ACME Inc.",
+            },
+        },
+    ],
+)
+def test_student_model_with_valid_content(kwargs):
+    """Tests a valid Student model does not raise ValidationError."""
+
+    try:
+        Student(**kwargs)
+    except ValidationError:
+        pytest.fail(f"Valid Student model with {kwargs} should not raise exceptions.")
+
+
+@pytest.mark.parametrize(
+    "kwargs, error",
+    [
+        (
+            {"first_name": None, "last_name": "Doe", "gender": Gender.MALE},
+            "first_name\n  none is not an allowed value",
+        ),
+        (
+            {"first_name": "Jane", "last_name": None, "gender": Gender.FEMALE},
+            "last_name\n  none is not an allowed value",
+        ),
+        (
+            {"first_name": "Jane", "last_name": "Doe", "gender": None},
+            "gender\n  none is not an allowed value",
+        ),
+        (
+            {"first_name": "John", "last_name": "Doe", "gender": "monsieur"},
+            "gender\n  value is not a valid enumeration member",
+        ),
+        (
+            {"last_name": "Doe", "gender": Gender.MALE},
+            "first_name\n  field required",
+        ),
+        (
+            {"first_name": "Jane", "gender": Gender.FEMALE},
+            "last_name\n  field required",
+        ),
+        (
+            {"first_name": "Jane", "last_name": "Doe"},
+            "gender\n  field required",
+        ),
+    ],
+)
+def test_student_model_with_invalid_content(kwargs, error):
+    """Tests a invalid Student model raises a ValidationError."""
+
+    with pytest.raises(ValidationError, match=error):
+        Student(**kwargs)
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {
+            "datespan": {
+                "start": ArrowDate("2021/01/01"),
+                "end": ArrowDate("2021/12/31"),
+            },
+            "duration": 23,
+            "scope": CertificateScope.FORMATION,
+            "manager": {
+                "position": "CEO",
+                "last_name": "Agarwal",
+                "first_name": "Anant",
+            },
+        },
+    ],
+)
+def test_session_model_with_valid_content(kwargs):
+    """Tests a valid Session model does not raise ValidationError."""
+
+    try:
+        Session(**kwargs)
+    except ValidationError:
+        pytest.fail(f"Valid Session model with {kwargs} should not raise exceptions.")
+
+
+@pytest.mark.parametrize(
+    "kwargs, error",
+    [
+        (
+            {
+                "datespan": ArrowDate(date(2021, 1, 1)),
+                "duration": 23,
+                "scope": CertificateScope.FORMATION,
+                "manager": {
+                    "position": "CEO",
+                    "last_name": "Agarwal",
+                    "first_name": "Anant",
+                },
+            },
+            "datespan\n  value is not a valid dict",
+        ),
+        (
+            {
+                "datespan": {
+                    "start": ArrowDate("2021/01/01"),
+                    "end": ArrowDate("2021/12/31"),
+                },
+                "duration": "23 days",
+                "scope": CertificateScope.FORMATION,
+                "manager": {
+                    "position": "CEO",
+                    "last_name": "Agarwal",
+                    "first_name": "Anant",
+                },
+            },
+            "duration\n  value is not a valid integer",
+        ),
+        (
+            {
+                "datespan": {
+                    "start": ArrowDate("2021/01/01"),
+                    "end": ArrowDate("2021/12/31"),
+                },
+                "duration": 23,
+                "scope": "formation",
+                "manager": {
+                    "position": "CEO",
+                    "last_name": "Agarwal",
+                    "first_name": "Anant",
+                },
+            },
+            "scope\n  value is not a valid enumeration member",
+        ),
+        (
+            {
+                "datespan": {
+                    "start": ArrowDate("2021/01/01"),
+                    "end": ArrowDate("2021/12/31"),
+                },
+                "duration": 23,
+                "scope": CertificateScope.FORMATION,
+                "manager": "CEO Agarwal Anant",
+            },
+            "manager\n  value is not a valid dict",
+        ),
+        (
+            {
+                "duration": 23,
+                "scope": CertificateScope.FORMATION,
+                "manager": {
+                    "position": "CEO",
+                    "last_name": "Agarwal",
+                    "first_name": "Anant",
+                },
+            },
+            "datespan\n  field required",
+        ),
+        (
+            {
+                "datespan": {
+                    "start": ArrowDate("2021/01/01"),
+                    "end": ArrowDate("2021/12/31"),
+                },
+                "scope": CertificateScope.FORMATION,
+                "manager": {
+                    "position": "CEO",
+                    "last_name": "Agarwal",
+                    "first_name": "Anant",
+                },
+            },
+            "duration\n  field required",
+        ),
+        (
+            {
+                "datespan": {
+                    "start": ArrowDate("2021/01/01"),
+                    "end": ArrowDate("2021/12/31"),
+                },
+                "duration": 23,
+                "manager": {
+                    "position": "CEO",
+                    "last_name": "Agarwal",
+                    "first_name": "Anant",
+                },
+            },
+            "scope\n  field required",
+        ),
+        (
+            {
+                "datespan": {
+                    "start": ArrowDate("2021/01/01"),
+                    "end": ArrowDate("2021/12/31"),
+                },
+                "duration": 23,
+                "scope": CertificateScope.FORMATION,
+            },
+            "manager\n  field required",
+        ),
+    ],
+)
+def test_session_model_with_invalid_content(kwargs, error):
+    """Tests a invalid Session model raises a ValidationError."""
+
+    with pytest.raises(ValidationError, match=error):
+        Session(**kwargs)
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {
+            "name": "edX Demonstration Course",
+            "session": {
+                "datespan": {
+                    "start": ArrowDate("2021/01/01"),
+                    "end": ArrowDate("2021/12/31"),
+                },
+                "duration": 23,
+                "scope": CertificateScope.FORMATION,
+                "manager": {
+                    "position": "CEO",
+                    "last_name": "Agarwal",
+                    "first_name": "Anant",
+                },
+            },
+            "organization": {
+                "name": "edx",
+                "manager": {
+                    "position": "CEO",
+                    "last_name": "Agarwal",
+                    "first_name": "Anant",
+                },
+                "location": "Boston, MA",
+            },
+        },
+    ],
+)
+def test_course_model_with_valid_content(kwargs):
+    """Tests a valid Course model does not raise ValidationError."""
+
+    try:
+        Course(**kwargs)
+    except ValidationError:
+        pytest.fail(f"Valid Course model with {kwargs} should not raise exceptions.")
+
+
+@pytest.mark.parametrize(
+    "kwargs, error",
+    [
+        (
+            {
+                "name": None,
+                "session": {
+                    "datespan": {
+                        "start": ArrowDate("2021/01/01"),
+                        "end": ArrowDate("2021/12/31"),
+                    },
+                    "duration": 23,
+                    "scope": CertificateScope.FORMATION,
+                    "manager": {
+                        "position": "CEO",
+                        "last_name": "Agarwal",
+                        "first_name": "Anant",
+                    },
+                },
+                "organization": {
+                    "name": "edx",
+                    "manager": {
+                        "position": "CEO",
+                        "last_name": "Agarwal",
+                        "first_name": "Anant",
+                    },
+                    "location": "Boston, MA",
+                },
+            },
+            "name\n  none is not an allowed value",
+        ),
+        (
+            {
+                "name": "edX Demonstration Course",
+                "session": None,
+                "organization": {
+                    "name": "edx",
+                    "manager": {
+                        "position": "CEO",
+                        "last_name": "Agarwal",
+                        "first_name": "Anant",
+                    },
+                    "location": "Boston, MA",
+                },
+            },
+            "session\n  none is not an allowed value",
+        ),
+        (
+            {
+                "name": "edX Demonstration Course",
+                "session": {
+                    "datespan": {
+                        "start": ArrowDate("2021/01/01"),
+                        "end": ArrowDate("2021/12/31"),
+                    },
+                    "duration": 23,
+                    "scope": CertificateScope.FORMATION,
+                    "manager": {
+                        "position": "CEO",
+                        "last_name": "Agarwal",
+                        "first_name": "Anant",
+                    },
+                },
+                "organization": None,
+            },
+            "organization\n  none is not an allowed value",
+        ),
+        (
+            {
+                "name": "edX Demonstration Course",
+                "session": "session 234",
+                "organization": {
+                    "name": "edx",
+                    "manager": {
+                        "position": "CEO",
+                        "last_name": "Agarwal",
+                        "first_name": "Anant",
+                    },
+                    "location": "Boston, MA",
+                },
+            },
+            "session\n  value is not a valid dict",
+        ),
+        (
+            {
+                "name": "edX Demonstration Course",
+                "session": {
+                    "datespan": {
+                        "start": ArrowDate("2021/01/01"),
+                        "end": ArrowDate("2021/12/31"),
+                    },
+                    "duration": 23,
+                    "scope": CertificateScope.FORMATION,
+                    "manager": {
+                        "position": "CEO",
+                        "last_name": "Agarwal",
+                        "first_name": "Anant",
+                    },
+                },
+                "organization": "edx",
+            },
+            "organization\n  value is not a valid dict",
+        ),
+        (
+            {
+                "session": {
+                    "datespan": {
+                        "start": ArrowDate("2021/01/01"),
+                        "end": ArrowDate("2021/12/31"),
+                    },
+                    "duration": 23,
+                    "scope": CertificateScope.FORMATION,
+                    "manager": {
+                        "position": "CEO",
+                        "last_name": "Agarwal",
+                        "first_name": "Anant",
+                    },
+                },
+                "organization": {
+                    "name": "edx",
+                    "manager": {
+                        "position": "CEO",
+                        "last_name": "Agarwal",
+                        "first_name": "Anant",
+                    },
+                    "location": "Boston, MA",
+                },
+            },
+            "name\n  field required",
+        ),
+        (
+            {
+                "name": "edX Demonstration Course",
+                "organization": {
+                    "name": "edx",
+                    "manager": {
+                        "position": "CEO",
+                        "last_name": "Agarwal",
+                        "first_name": "Anant",
+                    },
+                    "location": "Boston, MA",
+                },
+            },
+            "session\n  field required",
+        ),
+        (
+            {
+                "name": "edX Demonstration Course",
+                "session": {
+                    "datespan": {
+                        "start": ArrowDate("2021/01/01"),
+                        "end": ArrowDate("2021/12/31"),
+                    },
+                    "duration": 23,
+                    "scope": CertificateScope.FORMATION,
+                    "manager": {
+                        "position": "CEO",
+                        "last_name": "Agarwal",
+                        "first_name": "Anant",
+                    },
+                },
+            },
+            "organization\n  field required",
+        ),
+    ],
+)
+def test_course_model_with_invalid_content(kwargs, error):
+    """Tests a invalid Course model raises a ValidationError."""
+
+    with pytest.raises(ValidationError, match=error):
+        Course(**kwargs)
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {
+            "identifier": "ab9fe733-5b4b-485c-b0c2-f28d920c8588",
             "course": {
                 "name": "edX Demonstration Course",
                 "session": {
-                    "date": {
-                        "from": "03/02/2015",
-                        "to": "06/05/2015",
+                    "datespan": {
+                        "start": ArrowDate("2021/01/01"),
+                        "end": ArrowDate("2021/12/31"),
                     },
-                    "scope": "action de formation par apprentissage",
                     "duration": 23,
+                    "scope": CertificateScope.FORMATION,
                     "manager": {
-                        "position": "CHRO",
-                        "last_name": "Riggs",
-                        "first_name": "Martin",
+                        "position": "CEO",
+                        "last_name": "Agarwal",
+                        "first_name": "Anant",
                     },
                 },
                 "organization": {
@@ -49,13 +688,798 @@ def test_realisation_certificate_fetch_context(monkeypatch):
                 },
             },
             "student": {
-                "gender": "Mme",
-                "first_name": "Jane",
+                "first_name": "John",
                 "last_name": "Doe",
-                "organization": {"name": "ACME inc."},
+                "gender": Gender.MALE,
+                "organization": {
+                    "name": "ACME Inc.",
+                },
             },
-            "creation_date": datetime.strftime(freezed_now, "%d/%m/%Y"),
-            "delivery_stamp": str(freezed_now.isoformat()),
+            "creation_date": datetime(2021, 1, 1),
+            "delivery_stamp": datetime(2021, 1, 1),
+        },
+    ],
+)
+def test_context_model_with_valid_content(kwargs):
+    """Tests a valid Context model does not raise ValidationError."""
+
+    try:
+        ContextModel(**kwargs)
+    except ValidationError:
+        pytest.fail(f"Valid Context model with {kwargs} should not raise exceptions.")
+
+
+@pytest.mark.parametrize(
+    "kwargs, error",
+    [
+        (
+            {
+                "identifier": None,
+                "course": {
+                    "name": "edX Demonstration Course",
+                    "session": {
+                        "datespan": {
+                            "start": ArrowDate("2021/01/01"),
+                            "end": ArrowDate("2021/12/31"),
+                        },
+                        "duration": 23,
+                        "scope": CertificateScope.FORMATION,
+                        "manager": {
+                            "position": "CEO",
+                            "last_name": "Agarwal",
+                            "first_name": "Anant",
+                        },
+                    },
+                    "organization": {
+                        "name": "edx",
+                        "manager": {
+                            "position": "CEO",
+                            "last_name": "Agarwal",
+                            "first_name": "Anant",
+                        },
+                        "location": "Boston, MA",
+                    },
+                },
+                "student": {
+                    "first_name": "John",
+                    "last_name": "Doe",
+                    "gender": Gender.MALE,
+                    "organization": {
+                        "name": "ACME Inc.",
+                    },
+                },
+                "creation_date": datetime(2021, 1, 1),
+                "delivery_stamp": datetime(2021, 1, 1),
+            },
+            "identifier\n  none is not an allowed value",
+        ),
+        (
+            {
+                "identifier": "ab9fe733-5b4b-485c-b0c2-f28d920c8588",
+                "course": None,
+                "student": {
+                    "first_name": "John",
+                    "last_name": "Doe",
+                    "gender": Gender.MALE,
+                    "organization": {
+                        "name": "ACME Inc.",
+                    },
+                },
+                "creation_date": datetime(2021, 1, 1),
+                "delivery_stamp": datetime(2021, 1, 1),
+            },
+            "course\n  none is not an allowed value",
+        ),
+        (
+            {
+                "identifier": "ab9fe733-5b4b-485c-b0c2-f28d920c8588",
+                "course": {
+                    "name": "edX Demonstration Course",
+                    "session": {
+                        "datespan": {
+                            "start": ArrowDate("2021/01/01"),
+                            "end": ArrowDate("2021/12/31"),
+                        },
+                        "duration": 23,
+                        "scope": CertificateScope.FORMATION,
+                        "manager": {
+                            "position": "CEO",
+                            "last_name": "Agarwal",
+                            "first_name": "Anant",
+                        },
+                    },
+                    "organization": {
+                        "name": "edx",
+                        "manager": {
+                            "position": "CEO",
+                            "last_name": "Agarwal",
+                            "first_name": "Anant",
+                        },
+                        "location": "Boston, MA",
+                    },
+                },
+                "student": None,
+                "creation_date": datetime(2021, 1, 1),
+                "delivery_stamp": datetime(2021, 1, 1),
+            },
+            "student\n  none is not an allowed value",
+        ),
+        (
+            {
+                "identifier": "ab9fe733-5b4b-485c-b0c2-f28d920c8588",
+                "course": {
+                    "name": "edX Demonstration Course",
+                    "session": {
+                        "datespan": {
+                            "start": ArrowDate("2021/01/01"),
+                            "end": ArrowDate("2021/12/31"),
+                        },
+                        "duration": 23,
+                        "scope": CertificateScope.FORMATION,
+                        "manager": {
+                            "position": "CEO",
+                            "last_name": "Agarwal",
+                            "first_name": "Anant",
+                        },
+                    },
+                    "organization": {
+                        "name": "edx",
+                        "manager": {
+                            "position": "CEO",
+                            "last_name": "Agarwal",
+                            "first_name": "Anant",
+                        },
+                        "location": "Boston, MA",
+                    },
+                },
+                "student": {
+                    "first_name": "John",
+                    "last_name": "Doe",
+                    "gender": Gender.MALE,
+                    "organization": {
+                        "name": "ACME Inc.",
+                    },
+                },
+                "creation_date": None,
+                "delivery_stamp": datetime(2021, 1, 1),
+            },
+            "creation_date\n  none is not an allowed value",
+        ),
+        (
+            {
+                "identifier": "ab9fe733-5b4b-485c-b0c2-f28d920c8588",
+                "course": {
+                    "name": "edX Demonstration Course",
+                    "session": {
+                        "datespan": {
+                            "start": ArrowDate(date(2021, 1, 1)),
+                            "end": ArrowDate(date(2021, 12, 31)),
+                        },
+                        "duration": 23,
+                        "scope": CertificateScope.FORMATION,
+                        "manager": {
+                            "position": "CEO",
+                            "last_name": "Agarwal",
+                            "first_name": "Anant",
+                        },
+                    },
+                    "organization": {
+                        "name": "edx",
+                        "manager": {
+                            "position": "CEO",
+                            "last_name": "Agarwal",
+                            "first_name": "Anant",
+                        },
+                        "location": "Boston, MA",
+                    },
+                },
+                "student": {
+                    "first_name": "John",
+                    "last_name": "Doe",
+                    "gender": Gender.MALE,
+                },
+                "creation_date": datetime(2021, 1, 1),
+                "delivery_stamp": None,
+            },
+            "delivery_stamp\n  none is not an allowed value",
+        ),
+        (
+            {
+                "identifier": "abcd1234",
+                "course": {
+                    "name": "edX Demonstration Course",
+                    "session": {
+                        "datespan": {
+                            "start": ArrowDate("2021/01/01"),
+                            "end": ArrowDate("2021/12/31"),
+                        },
+                        "duration": 23,
+                        "scope": CertificateScope.FORMATION,
+                        "manager": {
+                            "position": "CEO",
+                            "last_name": "Agarwal",
+                            "first_name": "Anant",
+                        },
+                    },
+                    "organization": {
+                        "name": "edx",
+                        "manager": {
+                            "position": "CEO",
+                            "last_name": "Agarwal",
+                            "first_name": "Anant",
+                        },
+                        "location": "Boston, MA",
+                    },
+                },
+                "student": {
+                    "first_name": "John",
+                    "last_name": "Doe",
+                    "gender": Gender.MALE,
+                    "organization": {
+                        "name": "ACME Inc.",
+                    },
+                },
+                "creation_date": datetime(2021, 1, 1),
+                "delivery_stamp": datetime(2021, 1, 1),
+            },
+            "identifier\n  value is not a valid uuid",
+        ),
+        (
+            {
+                "identifier": "ab9fe733-5b4b-485c-b0c2-f28d920c8588",
+                "course": "edX Demonstration Course",
+                "student": {
+                    "first_name": "John",
+                    "last_name": "Doe",
+                    "gender": Gender.MALE,
+                    "organization": {
+                        "name": "ACME Inc.",
+                    },
+                },
+                "creation_date": datetime(2021, 1, 1),
+                "delivery_stamp": datetime(2021, 1, 1),
+            },
+            "course\n  value is not a valid dict",
+        ),
+        (
+            {
+                "identifier": "ab9fe733-5b4b-485c-b0c2-f28d920c8588",
+                "course": {
+                    "name": "edX Demonstration Course",
+                    "session": {
+                        "datespan": {
+                            "start": ArrowDate("2021/01/01"),
+                            "end": ArrowDate("2021/12/31"),
+                        },
+                        "duration": 23,
+                        "scope": CertificateScope.FORMATION,
+                        "manager": {
+                            "position": "CEO",
+                            "last_name": "Agarwal",
+                            "first_name": "Anant",
+                        },
+                    },
+                    "organization": {
+                        "name": "edx",
+                        "manager": {
+                            "position": "CEO",
+                            "last_name": "Agarwal",
+                            "first_name": "Anant",
+                        },
+                        "location": "Boston, MA",
+                    },
+                },
+                "student": "John Doe",
+                "creation_date": datetime(2021, 1, 1),
+                "delivery_stamp": datetime(2021, 1, 1),
+            },
+            "student\n  value is not a valid dict",
+        ),
+        (
+            {
+                "identifier": "ab9fe733-5b4b-485c-b0c2-f28d920c8588",
+                "course": {
+                    "name": "edX Demonstration Course",
+                    "session": {
+                        "datespan": {
+                            "start": ArrowDate("2021/01/01"),
+                            "end": ArrowDate("2021/12/31"),
+                        },
+                        "duration": 23,
+                        "scope": CertificateScope.FORMATION,
+                        "manager": {
+                            "position": "CEO",
+                            "last_name": "Agarwal",
+                            "first_name": "Anant",
+                        },
+                    },
+                    "organization": {
+                        "name": "edx",
+                        "manager": {
+                            "position": "CEO",
+                            "last_name": "Agarwal",
+                            "first_name": "Anant",
+                        },
+                        "location": "Boston, MA",
+                    },
+                },
+                "student": {
+                    "first_name": "John",
+                    "last_name": "Doe",
+                    "gender": Gender.MALE,
+                    "organization": {
+                        "name": "ACME Inc.",
+                    },
+                },
+                "creation_date": "2021-01-01",
+                "delivery_stamp": datetime(2021, 1, 1),
+            },
+            "creation_date\n  invalid datetime format",
+        ),
+        (
+            {
+                "identifier": "ab9fe733-5b4b-485c-b0c2-f28d920c8588",
+                "course": {
+                    "name": "edX Demonstration Course",
+                    "session": {
+                        "datespan": {
+                            "start": ArrowDate(date(2021, 1, 1)),
+                            "end": ArrowDate(date(2021, 12, 31)),
+                        },
+                        "duration": 23,
+                        "scope": CertificateScope.FORMATION,
+                        "manager": {
+                            "position": "CEO",
+                            "last_name": "Agarwal",
+                            "first_name": "Anant",
+                        },
+                    },
+                    "organization": {
+                        "name": "edx",
+                        "manager": {
+                            "position": "CEO",
+                            "last_name": "Agarwal",
+                            "first_name": "Anant",
+                        },
+                        "location": "Boston, MA",
+                    },
+                },
+                "student": {
+                    "first_name": "John",
+                    "last_name": "Doe",
+                    "gender": Gender.MALE,
+                },
+                "creation_date": datetime(2021, 1, 1),
+                "delivery_stamp": "2021-01-01",
+            },
+            "delivery_stamp\n  invalid datetime format",
+        ),
+        (
+            {
+                "course": {
+                    "name": "edX Demonstration Course",
+                    "session": {
+                        "datespan": {
+                            "start": ArrowDate("2021/01/01"),
+                            "end": ArrowDate("2021/12/31"),
+                        },
+                        "duration": 23,
+                        "scope": CertificateScope.FORMATION,
+                        "manager": {
+                            "position": "CEO",
+                            "last_name": "Agarwal",
+                            "first_name": "Anant",
+                        },
+                    },
+                    "organization": {
+                        "name": "edx",
+                        "manager": {
+                            "position": "CEO",
+                            "last_name": "Agarwal",
+                            "first_name": "Anant",
+                        },
+                        "location": "Boston, MA",
+                    },
+                },
+                "student": {
+                    "first_name": "John",
+                    "last_name": "Doe",
+                    "gender": Gender.MALE,
+                    "organization": {
+                        "name": "ACME Inc.",
+                    },
+                },
+                "creation_date": datetime(2021, 1, 1),
+                "delivery_stamp": datetime(2021, 1, 1),
+            },
+            "identifier\n  field required",
+        ),
+        (
+            {
+                "identifier": "ab9fe733-5b4b-485c-b0c2-f28d920c8588",
+                "student": {
+                    "first_name": "John",
+                    "last_name": "Doe",
+                    "gender": Gender.MALE,
+                    "organization": {
+                        "name": "ACME Inc.",
+                    },
+                },
+                "creation_date": datetime(2021, 1, 1),
+                "delivery_stamp": datetime(2021, 1, 1),
+            },
+            "course\n  field required",
+        ),
+        (
+            {
+                "identifier": "ab9fe733-5b4b-485c-b0c2-f28d920c8588",
+                "course": {
+                    "name": "edX Demonstration Course",
+                    "session": {
+                        "datespan": {
+                            "start": ArrowDate("2021/01/01"),
+                            "end": ArrowDate("2021/12/31"),
+                        },
+                        "duration": 23,
+                        "scope": CertificateScope.FORMATION,
+                        "manager": {
+                            "position": "CEO",
+                            "last_name": "Agarwal",
+                            "first_name": "Anant",
+                        },
+                    },
+                    "organization": {
+                        "name": "edx",
+                        "manager": {
+                            "position": "CEO",
+                            "last_name": "Agarwal",
+                            "first_name": "Anant",
+                        },
+                        "location": "Boston, MA",
+                    },
+                },
+                "creation_date": datetime(2021, 1, 1),
+                "delivery_stamp": datetime(2021, 1, 1),
+            },
+            "student\n  field required",
+        ),
+        (
+            {
+                "identifier": "ab9fe733-5b4b-485c-b0c2-f28d920c8588",
+                "course": {
+                    "name": "edX Demonstration Course",
+                    "session": {
+                        "datespan": {
+                            "start": ArrowDate("2021/01/01"),
+                            "end": ArrowDate("2021/12/31"),
+                        },
+                        "duration": 23,
+                        "scope": CertificateScope.FORMATION,
+                        "manager": {
+                            "position": "CEO",
+                            "last_name": "Agarwal",
+                            "first_name": "Anant",
+                        },
+                    },
+                    "organization": {
+                        "name": "edx",
+                        "manager": {
+                            "position": "CEO",
+                            "last_name": "Agarwal",
+                            "first_name": "Anant",
+                        },
+                        "location": "Boston, MA",
+                    },
+                },
+                "student": {
+                    "first_name": "John",
+                    "last_name": "Doe",
+                    "gender": Gender.MALE,
+                    "organization": {
+                        "name": "ACME Inc.",
+                    },
+                },
+                "delivery_stamp": datetime(2021, 1, 1),
+            },
+            "creation_date\n  field required",
+        ),
+        (
+            {
+                "identifier": "ab9fe733-5b4b-485c-b0c2-f28d920c8588",
+                "course": {
+                    "name": "edX Demonstration Course",
+                    "session": {
+                        "datespan": {
+                            "start": ArrowDate(date(2021, 1, 1)),
+                            "end": ArrowDate(date(2021, 12, 31)),
+                        },
+                        "duration": 23,
+                        "scope": CertificateScope.FORMATION,
+                        "manager": {
+                            "position": "CEO",
+                            "last_name": "Agarwal",
+                            "first_name": "Anant",
+                        },
+                    },
+                    "organization": {
+                        "name": "edx",
+                        "manager": {
+                            "position": "CEO",
+                            "last_name": "Agarwal",
+                            "first_name": "Anant",
+                        },
+                        "location": "Boston, MA",
+                    },
+                },
+                "student": {
+                    "first_name": "John",
+                    "last_name": "Doe",
+                    "gender": Gender.MALE,
+                },
+                "creation_date": datetime(2021, 1, 1),
+            },
+            "delivery_stamp\n  field required",
+        ),
+    ],
+)
+def test_context_model_with_invalid_content(kwargs, error):
+    """Tests a invalid Context model raises a ValidationError."""
+
+    with pytest.raises(ValidationError, match=error):
+        ContextModel(**kwargs)
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {
+            "student": {
+                "first_name": "John",
+                "last_name": "Doe",
+                "gender": Gender.MALE,
+                "organization": {
+                    "name": "ACME Inc.",
+                },
+            },
+            "course": {
+                "name": "edX Demonstration Course",
+                "session": {
+                    "datespan": {
+                        "start": ArrowDate(date(2021, 1, 1)),
+                        "end": ArrowDate(date(2021, 12, 31)),
+                    },
+                    "duration": 23,
+                    "scope": CertificateScope.FORMATION,
+                    "manager": {
+                        "position": "CEO",
+                        "last_name": "Agarwal",
+                        "first_name": "Anant",
+                    },
+                },
+                "organization": {
+                    "name": "edx",
+                    "manager": {
+                        "position": "CEO",
+                        "last_name": "Agarwal",
+                        "first_name": "Anant",
+                    },
+                    "location": "Boston, MA",
+                },
+            },
+        },
+    ],
+)
+def test_context_query_model_with_valid_content(kwargs):
+    """Tests a valid ContextQuery model does not raise ValidationError."""
+
+    try:
+        ContextQueryModel(**kwargs)
+    except ValidationError:
+        pytest.fail(
+            f"Valid ContextQuery model with {kwargs} should not raise exceptions."
+        )
+
+
+@pytest.mark.parametrize(
+    "kwargs, error",
+    [
+        (
+            {
+                "student": None,
+                "course": {
+                    "name": "edX Demonstration Course",
+                    "session": {
+                        "datespan": {
+                            "start": ArrowDate(date(2021, 1, 1)),
+                            "end": ArrowDate(date(2021, 12, 31)),
+                        },
+                        "duration": 23,
+                        "scope": CertificateScope.FORMATION,
+                        "manager": {
+                            "position": "CEO",
+                            "last_name": "Agarwal",
+                            "first_name": "Anant",
+                        },
+                    },
+                    "organization": {
+                        "name": "edx",
+                        "manager": {
+                            "position": "CEO",
+                            "last_name": "Agarwal",
+                            "first_name": "Anant",
+                        },
+                        "location": "Boston, MA",
+                    },
+                },
+            },
+            "student\n  none is not an allowed value",
+        ),
+        (
+            {
+                "student": {
+                    "first_name": "John",
+                    "last_name": "Doe",
+                    "gender": Gender.MALE,
+                },
+                "course": None,
+            },
+            "course\n  none is not an allowed value",
+        ),
+        (
+            {
+                "student": "John Doe",
+                "course": {
+                    "name": "edX Demonstration Course",
+                    "session": {
+                        "datespan": {
+                            "start": ArrowDate(date(2021, 1, 1)),
+                            "end": ArrowDate(date(2021, 12, 31)),
+                        },
+                        "duration": 23,
+                        "scope": CertificateScope.FORMATION,
+                        "manager": {
+                            "position": "CEO",
+                            "last_name": "Agarwal",
+                            "first_name": "Anant",
+                        },
+                    },
+                    "organization": {
+                        "name": "edx",
+                        "manager": {
+                            "position": "CEO",
+                            "last_name": "Agarwal",
+                            "first_name": "Anant",
+                        },
+                        "location": "Boston, MA",
+                    },
+                },
+            },
+            "student\n  value is not a valid dict",
+        ),
+        (
+            {
+                "student": {
+                    "first_name": "John",
+                    "last_name": "Doe",
+                    "gender": Gender.MALE,
+                },
+                "course": "edX Demonstration Course",
+            },
+            "course\n  value is not a valid dict",
+        ),
+        (
+            {
+                "course": {
+                    "name": "edX Demonstration Course",
+                    "session": {
+                        "datespan": {
+                            "start": ArrowDate(date(2021, 1, 1)),
+                            "end": ArrowDate(date(2021, 12, 31)),
+                        },
+                        "duration": 23,
+                        "scope": CertificateScope.FORMATION,
+                        "manager": {
+                            "position": "CEO",
+                            "last_name": "Agarwal",
+                            "first_name": "Anant",
+                        },
+                    },
+                    "organization": {
+                        "name": "edx",
+                        "manager": {
+                            "position": "CEO",
+                            "last_name": "Agarwal",
+                            "first_name": "Anant",
+                        },
+                        "location": "Boston, MA",
+                    },
+                },
+            },
+            "student\n  field required",
+        ),
+        (
+            {
+                "student": {
+                    "first_name": "John",
+                    "last_name": "Doe",
+                    "gender": Gender.MALE,
+                },
+            },
+            "course\n  field required",
+        ),
+    ],
+)
+def test_context_query_model_with_invalid_content(kwargs, error):
+    """Tests a invalid ContextQuery model raises a ValidationError."""
+
+    with pytest.raises(ValidationError, match=error):
+        ContextQueryModel(**kwargs)
+
+
+def test_realisation_certificate_fetch_context(monkeypatch):
+    """Test Realisation Certificate fetch_context"""
+
+    class TestCertificate(RealisationCertificate):
+        pass
+
+    identifier = uuid.uuid4()
+    test_certificate = TestCertificate(identifier=identifier)
+
+    freezed_now = datetime(2021, 1, 1)
+    monkeypatch.setattr("django.utils.timezone.now", lambda: freezed_now)
+
+    datespan = DateSpan(
+        start=ArrowDate(date(2015, 2, 3)),
+        end=ArrowDate(date(2015, 5, 6)),
+    )
+
+    course_manager = Manager(
+        position="CHRO",
+        last_name="Riggs",
+        first_name="Martin",
+    )
+
+    session = Session(
+        datespan=datespan,
+        scope=CertificateScope.APPRENTISSAGE,
+        duration=23,
+        manager=course_manager,
+    )
+
+    course_organization_manager = Manager(
+        position="CEO",
+        last_name="Agarwal",
+        first_name="Anant",
+    )
+
+    course_organization = Organization(
+        name="edx",
+        manager=course_organization_manager,
+        location="Boston, MA",
+    )
+
+    course = Course(
+        name="edX Demonstration Course",
+        session=session,
+        organization=course_organization,
+    )
+
+    student_organization = Organization(name="ACME inc.")
+
+    student = Student(
+        gender=Gender.FEMALE,
+        first_name="Jane",
+        last_name="Doe",
+        organization=student_organization,
+    )
+
+    expected = Context(
+        {
+            "identifier": str(identifier),
+            "course": course,
+            "student": student,
+            "creation_date": freezed_now,
+            "delivery_stamp": freezed_now.isoformat(),
         }
     )
 
@@ -63,9 +1487,9 @@ def test_realisation_certificate_fetch_context(monkeypatch):
         course={
             "name": "edX Demonstration Course",
             "session": {
-                "date": {
-                    "from": "03/02/2015",
-                    "to": "06/05/2015",
+                "datespan": {
+                    "start": ArrowDate(date(2015, 2, 3)),
+                    "end": ArrowDate(date(2015, 5, 6)),
                 },
                 "scope": "action de formation par apprentissage",
                 "duration": 23,

--- a/src/marion/.pylintrc
+++ b/src/marion/.pylintrc
@@ -3,7 +3,7 @@
 # A comma-separated list of package or module names from where C extensions may
 # be loaded. Extensions are loading into the active Python interpreter and may
 # run arbitrary code
-extension-pkg-whitelist=
+extension-pkg-whitelist=pydantic
 
 # Add files or directories to the blacklist. They should be base names, not
 # paths.

--- a/src/marion/marion/certificates/issuers/dummy.py
+++ b/src/marion/marion/certificates/issuers/dummy.py
@@ -1,31 +1,43 @@
 """Dummy Certificate"""
 
+from uuid import UUID
+
 from django.template import Context
 
+from pydantic import BaseModel, constr
+
 from .base import AbstractCertificate
+
+
+class ContextModel(BaseModel):
+    """Context model definition"""
+
+    identifier: UUID
+    fullname: constr(min_length=2, max_length=255)
+
+    class Config:
+        """Context model configuration"""
+
+        extra = "forbid"
+
+
+class ContextQueryModel(BaseModel):
+    """ContextQuery model definition"""
+
+    fullname: constr(min_length=2, max_length=255)
+
+    class Config:
+        """ContextQuery model configuration"""
+
+        extra = "forbid"
 
 
 class DummyCertificate(AbstractCertificate):
     """A test certificate for marion"""
 
-    context_schema = {
-        "type": "object",
-        "properties": {
-            "identifier": {"type": "string", "format": "uuid"},
-            "fullname": {"type": "string", "minLength": 2, "maxLength": 255},
-        },
-        "required": ["identifier", "fullname"],
-        "additionalProperties": False,
-    }
+    context_model = ContextModel
 
-    context_query_schema = {
-        "type": "object",
-        "properties": {
-            "fullname": {"type": "string", "minLength": 2, "maxLength": 255},
-        },
-        "required": ["fullname"],
-        "additionalProperties": False,
-    }
+    context_query_model = ContextQueryModel
 
     keywords = ["dummy", "test", "certificate"]
 
@@ -37,9 +49,8 @@ class DummyCertificate(AbstractCertificate):
 
         """
 
-        self.validate_context_query(context_query)
-        fullname = context_query.get("fullname", None)
-        return Context({"fullname": fullname, "identifier": self.identifier})
+        validated = self.validate_context_query(context_query)
+        return Context({"fullname": validated.fullname, "identifier": self.identifier})
 
     def get_title(self):
         """Define a custom title for the generated PDF metadata"""

--- a/src/marion/marion/certificates/migrations/0002_auto_20200910_1453.py
+++ b/src/marion/marion/certificates/migrations/0002_auto_20200910_1453.py
@@ -15,7 +15,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name="certificaterequest",
             name="context",
-            field=marion.certificates.models.JSONSchemaField(
+            field=marion.certificates.models.PydanticModelField(
                 blank=True,
                 editable=False,
                 help_text="Context used to render the certificate's template",
@@ -26,7 +26,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name="certificaterequest",
             name="context_query",
-            field=marion.certificates.models.JSONSchemaField(
+            field=marion.certificates.models.PydanticModelField(
                 help_text="Context will be fetched from those parameters",
                 verbose_name="Context query parameters",
             ),

--- a/src/marion/setup.cfg
+++ b/src/marion/setup.cfg
@@ -22,11 +22,13 @@ classifiers =
 [options]
 include_package_data = True
 install_requires =
+    arrow==1.0.3
     Django==3.1.7
     django-configurations==2.2
     djangorestframework==3.12.2
     jsonschema==3.2.0
     psycopg2-binary==2.8.6
+    pydantic==1.7.3
     WeasyPrint==52.4
 package_dir =
     =.

--- a/src/marion/setup.cfg
+++ b/src/marion/setup.cfg
@@ -55,11 +55,7 @@ dev =
     pytest-cov==2.11.1
     pytest-django==4.1.0
 ci =
-    twine==3.4.0
-gitlint =
-    gitlint==0.15.0
-    requests==2.25.1
-
+    twine==3.3.0
 [bdist_wheel]
 universal = 1
 


### PR DESCRIPTION
# Purpose

[pydantic](https://pydantic-docs.helpmanual.io/) seems to be a better solution for `marion`'s schema validation.
It is a more pythonic architecture to manipulate context data. For example, date can be manipulated as `datetime` python object and not as string anymore.

# Proposal 
All the JSON schema definitions have been replaced by pydantic models in issuers.