### PR TITLE
🔧(packages) improve dependencies management

### DIFF
--- a/src/marion/setup.cfg
+++ b/src/marion/setup.cfg
@@ -22,10 +22,10 @@ classifiers =
 [options]
 include_package_data = True
 install_requires =
-    arrow==1.0.3
-    djangorestframework==3.12.2
-    pydantic==1.8.1
-    WeasyPrint==52.4
+    arrow>=1.0.0 # pyup: ignore
+    djangorestframework>=3.12.0 # pyup: ignore
+    pydantic>=1.8.0 # pyup: ignore
+    WeasyPrint # pyup: ignore
 package_dir =
     =.
 packages = find:


### PR DESCRIPTION


## Purpose

Marion is now distributed as a Django application. Dependencies have to be unpinned to correctly use Marion as an application.

## Proposal

`arrow`, `djangorestframework`, `pydantic` and `Weasyprint` packages have been unpinned

