### PR TITLE
Release Marion & Howard 0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,13 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
 ## [Unreleased]
 
+## [0.1.0] - 2021-03-26
+
 ### Added
 
-- Add `howard` package that bundles fun-specific documents
 - Add `DocumentRequest` model, serializer and API viewset
 - Add `DummyDocument` example document issuer
 - Implement document issuer pattern
 
-[unreleased]: https://github.com/openfun/marion/compare/ebaa308c65580689f816e6071bcb4d4829a15ee8...master
+[unreleased]: https://github.com/openfun/marion/compare/v0.1.0...master
+[0.1.0]: https://github.com/openfun/marion/compare/ebaa308...v0.1.0

--- a/src/howard/CHANGELOG.md
+++ b/src/howard/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a
+Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0-howard] - 2021-03-26
+
+### Added
+
+- Draft realisation certificate issuer
+
+[unreleased]: https://github.com/openfun/marion/compare/v0.1.0-howard...master
+[0.1.0-howard]: https://github.com/openfun/marion/compare/090add7...v0.1.0-howard

--- a/src/howard/howard/__init__.py
+++ b/src/howard/howard/__init__.py
@@ -1,0 +1,23 @@
+"""Howard, FUN documents."""
+
+import importlib.metadata
+from pathlib import Path
+
+from setuptools.config import read_configuration
+
+
+def _get_version():
+    """Get version from installed package with a fallback to the setup.cfg version
+    string.
+
+    """
+
+    try:
+        return importlib.metadata.version("marion-howard")
+    except importlib.metadata.PackageNotFoundError:
+        return read_configuration(Path(__file__).parent / ".." / "setup.cfg")[
+            "metadata"
+        ]["version"]
+
+
+__version__ = _get_version()

--- a/src/howard/setup.cfg
+++ b/src/howard/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = marion-howard
-version = 0.0.1
+version = 0.1.0
 description = FUN documents for Marion, the documents factory
 long_description = file:README.md
 long_description_content_type = text/markdown
@@ -22,7 +22,7 @@ classifiers =
 [options]
 include_package_data = True
 install_requires =
-  marion==0.0.1
+  marion>=0.1.0
 package_dir =
     =.
 packages = find:

--- a/src/marion/setup.cfg
+++ b/src/marion/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = marion
-version = 0.0.1
+version = 0.1.0
 description = The documents factory
 long_description = file:README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
# Marion

## [0.1.0] - 2021-03-26

### Added

- Add `DocumentRequest` model, serializer and API viewset
- Add `DummyDocument` example document issuer
- Implement document issuer pattern

# Howard

## [0.1.0-howard] - 2021-03-26

### Added

- Draft realisation certificate issuer
