### PR TITLE
📦(project) update python package names

### DIFF
--- a/src/howard/setup.cfg
+++ b/src/howard/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-name = marion-howard
+name = django-marion-howard
 version = 0.1.0
 description = FUN documents for Marion, the documents factory
 long_description = file:README.md
@@ -22,7 +22,7 @@ classifiers =
 [options]
 include_package_data = True
 install_requires =
-  marion>=0.1.0
+  django-marion>=0.1.0
 package_dir =
     =.
 packages = find:

--- a/src/marion/setup.cfg
+++ b/src/marion/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-name = marion
+name = django-marion
 version = 0.1.0
 description = The documents factory
 long_description = file:README.md


### PR DESCRIPTION
## Purpose

Even not referenced on pypi, marion seems to be a reserved project name.

## Proposal

Let's switch to a django-prefixed pattern for project packages.
