### PR TITLE
Fix package version metadata fetching

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -202,7 +202,7 @@ jobs:
             cd marion && \
             python setup.py sdist bdist_wheel
       - run:
-          name: Build marion-howard python package
+          name: Build howard python package
           command: |
             cd howard && \
             python setup.py sdist bdist_wheel
@@ -236,7 +236,7 @@ jobs:
           name: List built marion package
           command: ls marion/dist/*
       - run:
-          name: List built marion-howard package
+          name: List built howard package
           command: ls howard/dist/*
       - run:
           name: Install base requirements (twine)
@@ -249,7 +249,7 @@ jobs:
           name: Upload marion's package to PyPI
           command: ~/.local/bin/twine upload --skip-existing marion/dist/*
       - run:
-          name: Upload marion-howard's package to PyPI
+          name: Upload howard's package to PyPI
           command: ~/.local/bin/twine upload --skip-existing howard/dist/*
 
 workflows:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- Package name in version metadata
+
 ## [0.1.0] - 2021-03-26
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
 ## [Unreleased]
 
+## [0.1.0] - 2021-04-06
+
 ### Fixed
 
 - Package name in version metadata
@@ -21,5 +23,6 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 - Add `DummyDocument` example document issuer
 - Implement document issuer pattern
 
-[unreleased]: https://github.com/openfun/marion/compare/v0.1.0...master
+[unreleased]: https://github.com/openfun/marion/compare/v0.1.1...master
+[0.1.1]: https://github.com/openfun/marion/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/openfun/marion/compare/ebaa308...v0.1.0

--- a/src/howard/CHANGELOG.md
+++ b/src/howard/CHANGELOG.md
@@ -8,6 +8,12 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
 ## [Unreleased]
 
+## [0.1.1-howard] - 2021-04-06
+
+### Changed
+
+- Upgrade `django-marion` dependency to `0.1.1`
+
 ### Fixed
 
 - Package name in version metadata
@@ -18,5 +24,6 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
 - Draft realisation certificate issuer
 
-[unreleased]: https://github.com/openfun/marion/compare/v0.1.0-howard...master
+[unreleased]: https://github.com/openfun/marion/compare/v0.1.1-howard...master
+[0.1.1-howard]: https://github.com/openfun/marion/compare/v0.1.0-howard...v0.1.1-howard
 [0.1.0-howard]: https://github.com/openfun/marion/compare/090add7...v0.1.0-howard

--- a/src/howard/CHANGELOG.md
+++ b/src/howard/CHANGELOG.md
@@ -8,6 +8,10 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- Package name in version metadata
+
 ## [0.1.0-howard] - 2021-03-26
 
 ### Added

--- a/src/howard/howard/__init__.py
+++ b/src/howard/howard/__init__.py
@@ -13,7 +13,7 @@ def _get_version():
     """
 
     try:
-        return importlib.metadata.version("marion-howard")
+        return importlib.metadata.version("django-marion-howard")
     except importlib.metadata.PackageNotFoundError:
         return read_configuration(Path(__file__).parent / ".." / "setup.cfg")[
             "metadata"

--- a/src/howard/setup.cfg
+++ b/src/howard/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = django-marion-howard
-version = 0.1.0
+version = 0.1.1
 description = FUN documents for Marion, the documents factory
 long_description = file:README.md
 long_description_content_type = text/markdown
@@ -22,7 +22,7 @@ classifiers =
 [options]
 include_package_data = True
 install_requires =
-  django-marion>=0.1.0
+  django-marion>=0.1.1
 package_dir =
     =.
 packages = find:

--- a/src/marion/marion/__init__.py
+++ b/src/marion/marion/__init__.py
@@ -13,7 +13,7 @@ def _get_version():
     """
 
     try:
-        return importlib.metadata.version("marion")
+        return importlib.metadata.version("django-marion")
     except importlib.metadata.PackageNotFoundError:
         return read_configuration(Path(__file__).parent / ".." / "setup.cfg")[
             "metadata"

--- a/src/marion/setup.cfg
+++ b/src/marion/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = django-marion
-version = 0.1.0
+version = 0.1.1
 description = The documents factory
 long_description = file:README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
## Purpose

We've recently renammed Marion & Howard packages as `marion` was a reserved name. Trying to import `marion` or `howard` in a standard installation fails as the `marion` package is not installed.

See detailled description of the issue in #27

## Proposal

- [x] fix package name in version metadata
- [x] bump marion release to 0.1.1
- [x] bump howard release to 0.1.1
