### PR TITLE
📝(project) change documentation primary color

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,6 +10,8 @@ copyright: 2021-present GIP FUN MOOC
 
 theme:
     name: material
+    palette:
+        primary: teal
 
 markdown_extensions:
     - attr_list


### PR DESCRIPTION
## Purpose

mk-docs based documentation proposes a color customization. By default, the primary color of the documentation is set to `indigo`.

## Proposal

- [x] set the `marion` documentation primary color to `teal`

![image](https://user-images.githubusercontent.com/56359895/113883425-6fc9ab00-97be-11eb-977d-9a7eec0c2a29.png)

