### PR TITLE
✏️(project) fix pytest typos

### DIFF
--- a/docs/contribute.md
+++ b/docs/contribute.md
@@ -55,7 +55,7 @@ $ bin/pylint
 
 ## Run tests
 
-Running tests with pytest can be achieved using:
+Running tests with `pytest` can be achieved using:
 
 ```
 $ make test

--- a/docs/issuer.md
+++ b/docs/issuer.md
@@ -472,6 +472,6 @@ $ http GET http://localhost:8000/api/documents/requests/
 ## Issuer testing
 
 Don't forget to test your business logic implemented in the `fetch_context`
-method of your issuer. We use pytest along with
+method of your issuer. We use `pytest` along with
 [hypothesis](https://hypothesis.readthedocs.io/en/latest/) as it has builtin
 support for [Pydantic](https://pydantic-docs.helpmanual.io/) models.


### PR DESCRIPTION
## Purpose

`pytest` should be written within an inline code zone in documentation content.

## Proposal

- [x] update `pytest` typo in documentation