### PR TITLE
Release Marion & Howard 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,11 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
 ## [Unreleased]
 
+## [0.2.0] - 2021-04-14
+
 ### Added
 
-- Add Django 3.2 compatibilty 
+- Add Django 3.2 compatibility 
 - Distribute a complete documentation
 
 ### Fixed
@@ -38,7 +40,8 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 - Add `DummyDocument` example document issuer
 - Implement document issuer pattern
 
-[unreleased]: https://github.com/openfun/marion/compare/v0.1.2...master
+[unreleased]: https://github.com/openfun/marion/compare/v0.2.0...master
+[0.2.0]: https://github.com/openfun/marion/compare/v0.1.2...v0.2.0
 [0.1.2]: https://github.com/openfun/marion/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/openfun/marion/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/openfun/marion/compare/ebaa308...v0.1.0

--- a/src/howard/setup.cfg
+++ b/src/howard/setup.cfg
@@ -13,6 +13,7 @@ classifiers =
     Development Status :: 4 - Beta
     Framework :: Django
     Framework :: Django :: 3.1
+    Framework :: Django :: 3.2
     Intended Audience :: Developers
     License :: OSI Approved :: MIT License
     Natural Language :: English

--- a/src/marion/setup.cfg
+++ b/src/marion/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = django-marion
-version = 0.1.2
+version = 0.2.0
 description = The documents factory
 long_description = file:README.md
 long_description_content_type = text/markdown
@@ -12,6 +12,7 @@ keywords = Django, LMS, learning, PDF
 classifiers =
     Development Status :: 4 - Beta
     Framework :: Django
+    Framework :: Django :: 3.1
     Framework :: Django :: 3.2
     Intended Audience :: Developers
     License :: OSI Approved :: MIT License


### PR DESCRIPTION
# Marion

## [0.2.0] - 2021-04-14

### Added

- Add Django 3.2 compatibility
- Distribute a complete documentation

### Fixed

- Add package description (README)
