### PR TITLE
Release Marion 0.3.0 & Howard 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,22 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
 ## [Unreleased]
 
+## [0.3.0] - 2021-06-08
+
+### Added
+
+- the `DocumentRequest` model now has a `get_document_path` helper
+
+### Fixed
+
+- Avoid caching pydantic model instance in the `PydanticModelField` to avoid
+  multiple models collisions
+
 ## [0.2.0] - 2021-04-14
 
 ### Added
 
-- Add Django 3.2 compatibility 
+- Add Django 3.2 compatibility
 - Distribute a complete documentation
 
 ### Fixed
@@ -40,7 +51,8 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 - Add `DummyDocument` example document issuer
 - Implement document issuer pattern
 
-[unreleased]: https://github.com/openfun/marion/compare/v0.2.0...master
+[unreleased]: https://github.com/openfun/marion/compare/v0.3.0...master
+[0.3.0]: https://github.com/openfun/marion/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/openfun/marion/compare/v0.1.2...v0.2.0
 [0.1.2]: https://github.com/openfun/marion/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/openfun/marion/compare/v0.1.0...v0.1.1

--- a/src/howard/CHANGELOG.md
+++ b/src/howard/CHANGELOG.md
@@ -8,6 +8,8 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
 ## [Unreleased]
 
+## [0.2.0-howard] - 2021-06-08
+
 ### Added
 
 - Add certificate issuer
@@ -40,7 +42,8 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
 - Draft realisation certificate issuer
 
-[unreleased]: https://github.com/openfun/marion/compare/v0.1.2-howard...master
+[unreleased]: https://github.com/openfun/marion/compare/v0.2.0-howard...master
+[0.2.0-howard]: https://github.com/openfun/marion/compare/v0.1.2-howard...v0.2.0-howard
 [0.1.2-howard]: https://github.com/openfun/marion/compare/v0.1.1-howard...v0.1.2-howard
 [0.1.1-howard]: https://github.com/openfun/marion/compare/v0.1.0-howard...v0.1.1-howard
 [0.1.0-howard]: https://github.com/openfun/marion/compare/090add7...v0.1.0-howard

--- a/src/howard/setup.cfg
+++ b/src/howard/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = django-marion-howard
-version = 0.1.2
+version = 0.2.0
 description = FUN documents for Marion, the documents factory
 long_description = file:README.md
 long_description_content_type = text/markdown

--- a/src/marion/setup.cfg
+++ b/src/marion/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = django-marion
-version = 0.2.0
+version = 0.3.0
 description = The documents factory
 long_description = file:README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
# Marion

## [0.3.0] - 2021-06-08

### Added

- the `DocumentRequest` model now has a `get_document_path` helper

### Fixed

- Avoid caching pydantic model instance in the `PydanticModelField` to avoid multiple models collisions

# Howard

## [0.2.0-howard] - 2021-06-08

### Added

- Add certificate issuer
- Rename and resize FUN logo
- Add invoice issuer

### Fixed

- Add package description (README)