### PR TITLE
Release Howard 0.2.3

### DIFF
--- a/src/howard/CHANGELOG.md
+++ b/src/howard/CHANGELOG.md
@@ -8,11 +8,14 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix path to compile translations after move local files
+
 ## [0.2.2-howard] - 2021-06-10
 
 ### Fixed
 
-- Fix path to compile translations after move local files
 - Fix translation typo in the `certificate` document
 
 ## [0.2.1-howard] - 2021-06-09

--- a/src/howard/CHANGELOG.md
+++ b/src/howard/CHANGELOG.md
@@ -8,6 +8,8 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
 ## [Unreleased]
 
+## [0.2.3-howard] - 2021-06-11
+
 ### Fixed
 
 - Fix path to compile translations after move local files
@@ -59,7 +61,8 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
 - Draft realisation certificate issuer
 
-[unreleased]: https://github.com/openfun/marion/compare/v0.2.2-howard...master
+[unreleased]: https://github.com/openfun/marion/compare/v0.2.3-howard...master
+[0.2.3-howard]: https://github.com/openfun/marion/compare/v0.2.2-howard...v0.2.3-howard
 [0.2.2-howard]: https://github.com/openfun/marion/compare/v0.2.1-howard...v0.2.2-howard
 [0.2.1-howard]: https://github.com/openfun/marion/compare/v0.2.0-howard...v0.2.1-howard
 [0.2.0-howard]: https://github.com/openfun/marion/compare/v0.1.2-howard...v0.2.0-howard

--- a/src/howard/setup.cfg
+++ b/src/howard/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = django-marion-howard
-version = 0.2.2
+version = 0.2.3
 description = FUN documents for Marion, the documents factory
 long_description = file:README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
# Howard

## [0.2.3-howard] - 2021-06-11

### Fixed

- Fix path to compile translations after move local files