### PR TITLE
Add the `shell` and `makemigrations` options to make

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- django management commands for `makemigrations` and `shell` to aid in 
+  development work when using the `make` command
+
 ## [0.3.0] - 2021-06-08
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -90,6 +90,18 @@ migrate: ## run database migrations
 	@$(MANAGE) migrate
 .PHONY: migrate
 
+makemigrations: ## run makemigrations
+	@$(COMPOSE) up -d postgresql
+	@$(WAIT_DB)
+	@$(MANAGE) makemigrations
+.PHONY: makemigrations
+
+shell: ## run python shell
+	@$(COMPOSE) up -d postgresql
+	@$(WAIT_DB)
+	@$(MANAGE) shell
+.PHONY: shell
+
 run: ## start the development server using Docker
 	@$(COMPOSE) up -d
 	@echo "Wait for postgresql to be up..."


### PR DESCRIPTION
## Purpose

Add the `shell` and `makemigrations` options to make 

## Description...

In the process or doing some dev work, found that these two useful django management tools were not available through the make command.

## Proposal

Add both commands
