### PR TITLE
🔖(patch) bump marion release to 0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
 ## [Unreleased]
 
+## [0.3.1] - 2021-09-02
+
 ### Added
 
 - `Weasyprint` 53.0+ is now needed
@@ -55,7 +57,8 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 - Add `DummyDocument` example document issuer
 - Implement document issuer pattern
 
-[unreleased]: https://github.com/openfun/marion/compare/v0.3.0...master
+[unreleased]: https://github.com/openfun/marion/compare/v0.3.1...master
+[0.3.0]: https://github.com/openfun/marion/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/openfun/marion/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/openfun/marion/compare/v0.1.2...v0.2.0
 [0.1.2]: https://github.com/openfun/marion/compare/v0.1.1...v0.1.2

--- a/src/marion/setup.cfg
+++ b/src/marion/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = django-marion
-version = 0.3.0
+version = 0.3.1
 description = The documents factory
 long_description = file:README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
# Marion

## [0.3.1] - 2021-09-02

### Added

- `Weasyprint` 53.0+ is now needed