### PR TITLE
Update Renovate bot configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,7 @@
     ],
     "commitMessagePrefix": "⬆️(project)",
     "commitMessageAction": "upgrade",
+    "commitBodyTable": true,
     "packageRules": [
         {
             "enabled": false,


### PR DESCRIPTION
## Purpose

In the renovate configuration, when activated, the flag `commitBodyTable` enables to append a table with all the updates in the
commit. 

## Proposal

To fit to our previous commit description with `pybot`, we have activated this flag.

