### PR TITLE
✨(marion) allow to create a document without persist

### DIFF
--- a/src/howard/CHANGELOG.md
+++ b/src/howard/CHANGELOG.md
@@ -8,6 +8,10 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+
+- Add a `save` argument to `AbstractDocument.create` method
+
 ## [0.2.4-howard] - 2021-06-15
 
 ### Removed


### PR DESCRIPTION
## Purpose

In some case we want to create a document without persisting it.
`AbstractDocument.create` method should be able to manage this point. In first case, it creates and persists document then return the document path. In other hand, it creates the document and returns it as bytes.

## Proposal

- [x] Add `persist` argument to `AbtractDocument.create` method

