### PR TITLE
Bump/howard marion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
 ## [Unreleased]
 
+## [0.3.2] - 2021-11-29
+
 ### Added
 
 - Create a `IssuerLazyChoiceField` to be able to update issuer field choices
@@ -66,8 +68,9 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 - Add `DummyDocument` example document issuer
 - Implement document issuer pattern
 
-[unreleased]: https://github.com/openfun/marion/compare/v0.3.1...master
-[0.3.0]: https://github.com/openfun/marion/compare/v0.3.0...v0.3.1
+[unreleased]: https://github.com/openfun/marion/compare/v0.3.2...master
+[0.3.2]: https://github.com/openfun/marion/compare/v0.3.1...v0.3.2
+[0.3.1]: https://github.com/openfun/marion/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/openfun/marion/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/openfun/marion/compare/v0.1.2...v0.2.0
 [0.1.2]: https://github.com/openfun/marion/compare/v0.1.1...v0.1.2

--- a/src/howard/CHANGELOG.md
+++ b/src/howard/CHANGELOG.md
@@ -8,6 +8,8 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
 ## [Unreleased]
 
+## [0.2.5-howard] - 2021-11-29
+
 ### Changed
 
 - Update InvoiceIssuer to generate both invoice and credit note
@@ -72,7 +74,8 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
 - Draft realisation certificate issuer
 
-[unreleased]: https://github.com/openfun/marion/compare/v0.2.4-howard...master
+[unreleased]: https://github.com/openfun/marion/compare/v0.2.5-howard...master
+[0.2.5-howard]: https://github.com/openfun/marion/compare/v0.2.4-howard...v0.2.5-howard
 [0.2.4-howard]: https://github.com/openfun/marion/compare/v0.2.3-howard...v0.2.4-howard
 [0.2.3-howard]: https://github.com/openfun/marion/compare/v0.2.2-howard...v0.2.3-howard
 [0.2.2-howard]: https://github.com/openfun/marion/compare/v0.2.1-howard...v0.2.2-howard

--- a/src/howard/setup.cfg
+++ b/src/howard/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = django-marion-howard
-version = 0.2.4
+version = 0.2.5
 description = FUN documents for Marion, the documents factory
 long_description = file:README.md
 long_description_content_type = text/markdown

--- a/src/marion/setup.cfg
+++ b/src/marion/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = django-marion
-version = 0.3.1
+version = 0.3.2
 description = The documents factory
 long_description = file:README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
## Purpose

In order to release a new version of Marion and Howard, we have to bump versions.

## Howard 0.2.5

### Changed

- Update InvoiceIssuer to generate both invoice and credit note
- Create a utils module to share code throughout the application

## Marion 0.3.2

### Added

- Create a `IssuerLazyChoiceField` to be able to update issuer field choices
  without creating migrations.

### Changed

- Add a `persist` argument to `AbstractDocument.create` method

## Proposal

- [x] Bump Howard to version 0.2.5
- [x] Bump Marion to version 0.3.2

