### PR TITLE
✨(howard) add optional field `creation_date` to certificate issuer

### DIFF
--- a/src/howard/CHANGELOG.md
+++ b/src/howard/CHANGELOG.md
@@ -8,6 +8,10 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+
+- Update CertificateIssuer to add an optional `creation_date` field into context_query
+
 ## [0.2.5-howard] - 2021-11-29
 
 ### Changed

--- a/src/howard/howard/templates/howard/certificate.html
+++ b/src/howard/howard/templates/howard/certificate.html
@@ -1,5 +1,6 @@
 {% load i18n %}
 {% load static %}
+{% load howard_tags %}
 
 <html>
   {% if debug %}
@@ -17,7 +18,11 @@
             <img src="{{ debug | yesno:",file://" }}{% static "howard/logo-fun.png" %}" />
           </div>
           <div class="organization">
-            <img src="{{ debug | yesno:",file://" }}{{ course.organization.logo }}" />
+              {% if course.organization.logo | is_path %}
+                    <img src="{{ debug | yesno:",file://" }}{{ course.organization.logo }}" />
+              {% else %}
+                    <img src="{{ course.organization.logo }}" />
+              {% endif %}
           </div>
         </div>
         <div class="title">
@@ -50,7 +55,11 @@
               {% translate "Stamp and signature of the course provider manager" %}
             </p>
             <div class="manager">
-              <img src="{{ debug | yesno:",file://" }}{{ course.organization.signature }}" />
+                {% if course.organization.signature | is_path %}
+                    <img src="{{ debug | yesno:",file://" }}{{ course.organization.signature }}" />
+                {% else %}
+                    <img src="{{ course.organization.signature }}" />
+                {% endif %}
             </div>
           </div>
         </section>

--- a/src/howard/howard/templatetags/howard_tags.py
+++ b/src/howard/howard/templatetags/howard_tags.py
@@ -1,0 +1,12 @@
+"""Howard template tags"""
+from pathlib import Path
+
+from django import template
+
+register = template.Library()
+
+
+@register.filter()
+def is_path(obj):
+    """Check if the provided object is a Path instance."""
+    return isinstance(obj, Path)

--- a/src/howard/howard/tests/issuers/test_certificate.py
+++ b/src/howard/howard/tests/issuers/test_certificate.py
@@ -14,7 +14,12 @@ from hypothesis import strategies as st
 
 
 @given(
-    st.builds(ContextQueryModel, student=st.builds(Student), course=st.builds(Course))
+    st.builds(
+        ContextQueryModel,
+        student=st.builds(Student),
+        course=st.builds(Course),
+        creation_date=st.datetimes(),
+    )
 )
 @settings(suppress_health_check=(HealthCheck.function_scoped_fixture,))
 def test_certificate_fetch_context(monkeypatch, context_query):
@@ -31,9 +36,39 @@ def test_certificate_fetch_context(monkeypatch, context_query):
     )
     expected = {
         "identifier": str(identifier),
-        "creation_date": freezed_now,
         "delivery_stamp": freezed_now.isoformat(),
         **context_query.dict(),
     }
+    context = test_certificate.fetch_context()
+    assert context == expected
+
+
+@given(
+    st.builds(ContextQueryModel, student=st.builds(Student), course=st.builds(Course))
+)
+@settings(suppress_health_check=(HealthCheck.function_scoped_fixture,))
+def test_certificate_default_creation_date(monkeypatch, context_query):
+    """
+    Context query `creation_date` property should be optional.
+    If no value is provided, the document `created` metadata should be used.
+    """
+
+    freezed_now = datetime.datetime(2021, 1, 1)
+    monkeypatch.setattr("django.utils.timezone.now", lambda: freezed_now)
+
+    identifier = uuid.uuid4()
+
+    test_certificate = CertificateDocument(
+        identifier=identifier,
+        context_query=context_query,
+    )
+    expected = {
+        "identifier": str(identifier),
+        "delivery_stamp": freezed_now.isoformat(),
+        **context_query.dict(),
+        "creation_date": freezed_now.isoformat(),
+    }
+
+    assert context_query.dict()["creation_date"] is None
     context = test_certificate.fetch_context()
     assert context == expected

--- a/src/howard/howard/tests/templatetags/test_howard_tags.py
+++ b/src/howard/howard/tests/templatetags/test_howard_tags.py
@@ -1,0 +1,15 @@
+"""Test suite for howard template tags"""
+from pathlib import Path
+
+from howard.templatetags.howard_tags import is_path
+from hypothesis import given
+from hypothesis import strategies as st
+from hypothesis.provisional import urls
+
+
+@given(st.builds(Path, urls()), urls())
+def test_howard_tags_is_path(path, not_path):
+    """Test the filter template tag howard_tags.is_path."""
+
+    assert is_path(path) is True
+    assert is_path(not_path) is False


### PR DESCRIPTION
## Purpose
1. In the case when a certificate is generated but not persisted, we should be able to provide the `creation_date` through the context query. CertificateIssuer context query should accept a `creation_date` property. This value should be optional and if it is not provided the `created` class property is used.

2. we should be able to pass a base 64 encoded image through context query. So signature and logo field validators should now accepts string  instead of path.

## Proposal

- [x] Add an optional `creation_date` field to CertificateIssuer context query
- [x] Update logo and signature fields validators to accept base64 encoded images.

