### PR TITLE
🔖(patch) bump howard to version 0.2.6

### DIFF
--- a/src/howard/CHANGELOG.md
+++ b/src/howard/CHANGELOG.md
@@ -8,6 +8,8 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
 ## [Unreleased]
 
+## [0.2.6-howard] - 2022-01-25
+
 ### Changed
 
 - Update CertificateIssuer to add an optional `creation_date` field into context_query
@@ -78,7 +80,8 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
 - Draft realisation certificate issuer
 
-[unreleased]: https://github.com/openfun/marion/compare/v0.2.5-howard...master
+[unreleased]: https://github.com/openfun/marion/compare/v0.2.6-howard...master
+[0.2.5-howard]: https://github.com/openfun/marion/compare/v0.2.5-howard...v0.2.6-howard
 [0.2.5-howard]: https://github.com/openfun/marion/compare/v0.2.4-howard...v0.2.5-howard
 [0.2.4-howard]: https://github.com/openfun/marion/compare/v0.2.3-howard...v0.2.4-howard
 [0.2.3-howard]: https://github.com/openfun/marion/compare/v0.2.2-howard...v0.2.3-howard

--- a/src/howard/setup.cfg
+++ b/src/howard/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = django-marion-howard
-version = 0.2.5
+version = 0.2.6
 description = FUN documents for Marion, the documents factory
 long_description = file:README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
### Changed

- Update CertificateIssuer to add an optional `creation_date` field
into context_query

