### PR TITLE
Hotfix/certificate template

### DIFF
--- a/src/howard/CHANGELOG.md
+++ b/src/howard/CHANGELOG.md
@@ -8,6 +8,8 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
 ## [Unreleased]
 
+## [0.2.7-howard] - 2022-01-25
+
 ### Fixed
 
 - Fix syntax error within CertificateIssuer template
@@ -84,8 +86,9 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
 - Draft realisation certificate issuer
 
-[unreleased]: https://github.com/openfun/marion/compare/v0.2.6-howard...master
-[0.2.5-howard]: https://github.com/openfun/marion/compare/v0.2.5-howard...v0.2.6-howard
+[unreleased]: https://github.com/openfun/marion/compare/v0.2.7-howard...master
+[0.2.7-howard]: https://github.com/openfun/marion/compare/v0.2.6-howard...v0.2.7-howard
+[0.2.6-howard]: https://github.com/openfun/marion/compare/v0.2.5-howard...v0.2.6-howard
 [0.2.5-howard]: https://github.com/openfun/marion/compare/v0.2.4-howard...v0.2.5-howard
 [0.2.4-howard]: https://github.com/openfun/marion/compare/v0.2.3-howard...v0.2.4-howard
 [0.2.3-howard]: https://github.com/openfun/marion/compare/v0.2.2-howard...v0.2.3-howard

--- a/src/howard/CHANGELOG.md
+++ b/src/howard/CHANGELOG.md
@@ -8,6 +8,10 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix syntax error within CertificateIssuer template
+
 ## [0.2.6-howard] - 2022-01-25
 
 ### Changed

--- a/src/howard/howard/templates/howard/certificate.html
+++ b/src/howard/howard/templates/howard/certificate.html
@@ -18,7 +18,7 @@
             <img src="{{ debug | yesno:",file://" }}{% static "howard/logo-fun.png" %}" />
           </div>
           <div class="organization">
-              {% if course.organization.logo | is_path %}
+              {% if course.organization.logo|is_path %}
                     <img src="{{ debug | yesno:",file://" }}{{ course.organization.logo }}" />
               {% else %}
                     <img src="{{ course.organization.logo }}" />
@@ -55,7 +55,7 @@
               {% translate "Stamp and signature of the course provider manager" %}
             </p>
             <div class="manager">
-                {% if course.organization.signature | is_path %}
+                {% if course.organization.signature|is_path %}
                     <img src="{{ debug | yesno:",file://" }}{{ course.organization.signature }}" />
                 {% else %}
                     <img src="{{ course.organization.signature }}" />

--- a/src/howard/setup.cfg
+++ b/src/howard/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = django-marion-howard
-version = 0.2.6
+version = 0.2.7
 description = FUN documents for Marion, the documents factory
 long_description = file:README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
## Purpose

There was extra spaces between the template tag is_path and its related variable which raised a TemplateSyntaxError during rendering.

## Proposal

- [x] Fix syntax error within certificate template
- [x] bump howard to version 0.2.7

