### PR TITLE
🐛(marion) use static storage class to open static files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
 - Add Django 4.0 compatibility
 
+## Fixed
+
+- Use static storage class to open static files
+
 ## [0.3.2] - 2021-11-29
 
 ### Added

--- a/sandbox/settings.py
+++ b/sandbox/settings.py
@@ -160,6 +160,7 @@ class Test(Base):
     """Test environment settings"""
 
     MEDIA_ROOT = Path(mkdtemp())
+    STATIC_ROOT = Path(mkdtemp())
 
     ROOT_URLCONF = "urls.debug"
 

--- a/src/marion/marion/tests/test_utils.py
+++ b/src/marion/marion/tests/test_utils.py
@@ -1,8 +1,12 @@
 """Tests for the marion.utils module"""
 
+import re
 from pathlib import Path
 
 from django.conf import settings
+from django.contrib.staticfiles.management.commands import collectstatic
+from django.templatetags.static import StaticNode
+from django.test import override_settings
 
 import marion
 from marion.utils import static_file_fetcher
@@ -14,7 +18,7 @@ def test_static_file_fetcher(fs):
 
     # Create a fake static file for the marion app
     relative_static_file_path = "marion/test.txt"
-    static_file_path = Path(f"{marion.__path__[0]}/static/{relative_static_file_path}")
+    static_file_path = Path(f"{settings.STATIC_ROOT}/{relative_static_file_path}")
     fs.create_file(static_file_path, contents="This is content.")
 
     # Fetch this file
@@ -38,5 +42,51 @@ def test_static_file_fetcher(fs):
     file_ = data.get("file_obj")
     assert file_.readlines() == [
         b"This is a different content.",
+    ]
+    file_.close()
+
+
+@override_settings(
+    STATICFILES_STORAGE="django.contrib.staticfiles.storage.ManifestStaticFilesStorage"
+)
+def test_static_file_fetcher_with_hashed_statics(fs):
+    """Test weasyprint custom static file fetcher with hashed static files."""
+
+    # Create a fake static file into marion app
+    relative_static_file_path = "marion/test.txt"
+    static_file_path = Path(f"{marion.__path__[0]}/static/{relative_static_file_path}")
+    fs.create_file(static_file_path, contents="This is content.")
+
+    # Collect static files to process the fresh new created static file test.txt
+    # As ManifestStaticFilesStorage is the active backend storage for static,
+    # it stores the file names it handles by appending the MD5 hash of the file’s
+    # content to the filename.
+    # In this way, we are able below to ensure that `static_file_fetcher` is able to
+    # access to those static files.
+    collectstatic.Command().handle(
+        clear=True,
+        dry_run=False,
+        ignore_patterns=[],
+        interactive=False,
+        link=False,
+        post_process=True,
+        use_default_ignore_patterns=True,
+        verbosity=0,
+    )
+
+    # Retrieve the static file path
+    path = f'file://{StaticNode.handle_simple("marion/test.txt")}'
+    # The file path should target the hashed static file
+    assert re.search(r"\/static\/marion\/test\.[a-f0-9]*\.txt$", path)
+
+    # Fetch the file
+    data = static_file_fetcher(path)
+
+    # The filename should contain a hash
+    assert re.search(r"^test\.[a-f0-9]*\.txt$", data.get("filename"))
+    assert data.get("mime_type") == "text/plain"
+    file_ = data.get("file_obj")
+    assert file_.readlines() == [
+        b"This is content.",
     ]
     file_.close()

--- a/src/marion/marion/utils.py
+++ b/src/marion/marion/utils.py
@@ -5,10 +5,12 @@ from pathlib import Path
 from urllib.parse import urlparse
 
 from django.conf import settings
-from django.contrib.staticfiles.finders import find
+from django.contrib.staticfiles.storage import get_storage_class
 from django.core.exceptions import SuspiciousFileOperation
 
 import weasyprint
+
+static_storage = get_storage_class(settings.STATICFILES_STORAGE)()
 
 
 def static_file_fetcher(url, *args, **kwargs):
@@ -35,9 +37,7 @@ def static_file_fetcher(url, *args, **kwargs):
 
         path = url_path.replace(settings.STATIC_URL, "", 1)
         try:
-            data["file_obj"] = open(  # pylint: disable=consider-using-with
-                find(path), "rb"
-            )
+            data["file_obj"] = static_storage.open(path, "rb")
         # A SuspiciousFileOperation is raised by Django if the file has been
         # found outside referenced static file paths. In this case, we ignore
         # this error and fallback to the default Weasyprint fetcher for files


### PR DESCRIPTION
## Purpose

`marion.utils.static_file_fetcher` method used previously the built-in method `open` to open static files. But it could lead to some issue when the configured static file storage generates extra static files (e.g: containing hash for cache purpose). In this case, the current logic was not able to find the related static file, but using the `open` method of the StaticFileStorage class allows us to find those files.

## Proposal

- [x] Retrieve the static file storage class then use its open method to open static files

