### PR TITLE
🔖(marion) bump to version 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,13 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
 ## [Unreleased]
 
+## [0.4.0] - 2022-08-05
+
 ### Added
 
 - Add Django 4.0 compatibility
 
-## Fixed
+### Fixed
 
 - Use static storage class to open static files
 
@@ -76,7 +78,8 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 - Add `DummyDocument` example document issuer
 - Implement document issuer pattern
 
-[unreleased]: https://github.com/openfun/marion/compare/v0.3.2...master
+[unreleased]: https://github.com/openfun/marion/compare/v0.4.0...master
+[0.4.0]: https://github.com/openfun/marion/compare/v0.3.2...0.4.0
 [0.3.2]: https://github.com/openfun/marion/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/openfun/marion/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/openfun/marion/compare/v0.2.0...v0.3.0

--- a/src/marion/setup.cfg
+++ b/src/marion/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = django-marion
-version = 0.3.2
+version = 0.4.0
 description = The documents factory
 long_description = file:README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
# Marion

## [0.4.0] - 2022-08-04

### Added
- Add Django 4.0 compatibility

### Fixed
- Use static storage class to open static files

