### PR TITLE
Howard - Upgrade marion to 0.4.0 then bump howard to version 0.3.0

### DIFF
--- a/src/howard/CHANGELOG.md
+++ b/src/howard/CHANGELOG.md
@@ -8,6 +8,8 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
 ## [Unreleased]
 
+## [0.3.0-howard] - 2022-08-05
+
 ### Changed
 
 - Enforce to use at least django-marion 0.4.0
@@ -90,7 +92,8 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
 - Draft realisation certificate issuer
 
-[unreleased]: https://github.com/openfun/marion/compare/v0.2.7-howard...master
+[unreleased]: https://github.com/openfun/marion/compare/v0.3.0-howard...master
+[0.3.0-howard]: https://github.com/openfun/marion/compare/v0.2.7-howard...v0.3.0-howard
 [0.2.7-howard]: https://github.com/openfun/marion/compare/v0.2.6-howard...v0.2.7-howard
 [0.2.6-howard]: https://github.com/openfun/marion/compare/v0.2.5-howard...v0.2.6-howard
 [0.2.5-howard]: https://github.com/openfun/marion/compare/v0.2.4-howard...v0.2.5-howard

--- a/src/howard/CHANGELOG.md
+++ b/src/howard/CHANGELOG.md
@@ -8,6 +8,10 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+
+- Enforce to use at least django-marion 0.4.0
+
 ## [0.2.7-howard] - 2022-01-25
 
 ### Fixed

--- a/src/howard/setup.cfg
+++ b/src/howard/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = django-marion-howard
-version = 0.2.7
+version = 0.3.0
 description = FUN documents for Marion, the documents factory
 long_description = file:README.md
 long_description_content_type = text/markdown

--- a/src/howard/setup.cfg
+++ b/src/howard/setup.cfg
@@ -23,7 +23,7 @@ classifiers =
 [options]
 include_package_data = True
 install_requires =
-  django-marion>=0.3.0
+  django-marion>=0.4.0
 packages = find:
 zip_safe = True
 


### PR DESCRIPTION
# Howard

## [0.4.0] - 2022-08-04

### Changed

- Enforce to use at least django-marion 0.4.0

