### PR TITLE
📝(project) update copyright holder

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020-present GIP FUN MOOC.
+Copyright (c) 2020-present France Université Numérique
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,7 +6,7 @@ site_author: Open FUN (France Universite Numerique)
 repo_name: openfun/marion
 repo_url: https://github.com/openfun/marion/
 
-copyright: 2021-present GIP FUN MOOC
+copyright: 2021-present France Université Numérique
 
 theme:
     name: material


### PR DESCRIPTION
## Purpose

The GIP FUN-MOOC has been renamed France Université Numérique since a few years.

## Proposal

Replace each occurence of GIP FUN-MOOC with France Université Numérique