### PR TITLE
Feat/create document with weasyprint options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 ### Added
 
 - Add Django 4.2 compatibility
+- Add `pdf_options` argument to `AbstractDocument.create` method
 
 ## [0.4.0] - 2022-08-05
 

--- a/src/marion/setup.cfg
+++ b/src/marion/setup.cfg
@@ -26,7 +26,7 @@ install_requires =
     arrow>=1.0.0
     djangorestframework>=3.12.0
     pydantic>=1.8.0
-    WeasyPrint>=53.0
+    WeasyPrint>=59.0
 packages = find:
 zip_safe = True
 


### PR DESCRIPTION
## Purpose

Weasyprint 59.0 introduces new options to pass to the `write_pdf` method. It could be interesting to allow marion consumers to be able to use them.

Since Weasyprint 59.0, the pdfminer extract_text method raises a `TypeError` when PDF compression is enable, so until the issue is fixed, we decide to disable it but allow consumers to enable it at their own risk.

https://github.com/Kozea/WeasyPrint/issues/1885
https://github.com/pdfminer/pdfminer.six/issues/886

## Proposal

- [x] Pin Weasyprint to version greater than equal to 59.0
- [x] Add `pdf_options` parameter to `AbstractDocument.create` method
- [x] Write tests
