### PR TITLE
🔖(all) bump marion & howard to version 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
 ## [Unreleased]
 
+## [0.5.0] - 2023-05-23
+
 ### Added
 
 - Add Django 4.2 compatibility
@@ -83,7 +85,8 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 - Add `DummyDocument` example document issuer
 - Implement document issuer pattern
 
-[unreleased]: https://github.com/openfun/marion/compare/v0.4.0...master
+[unreleased]: https://github.com/openfun/marion/compare/v0.5.0...master
+[0.5.0]: https://github.com/openfun/marion/compare/v0.4.0...0.5.0
 [0.4.0]: https://github.com/openfun/marion/compare/v0.3.2...0.4.0
 [0.3.2]: https://github.com/openfun/marion/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/openfun/marion/compare/v0.3.0...v0.3.1

--- a/src/howard/CHANGELOG.md
+++ b/src/howard/CHANGELOG.md
@@ -8,6 +8,8 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
 ## [Unreleased]
 
+## [0.5.0-howard] - 2023-05-23
+
 ### Changed
 
 - Enforce to use at least django-marion 0.5.0
@@ -102,7 +104,8 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
 - Draft realisation certificate issuer
 
-[unreleased]: https://github.com/openfun/marion/compare/v0.4.0-howard...master
+[unreleased]: https://github.com/openfun/marion/compare/v0.5.0-howard...master
+[0.5.0-howard]: https://github.com/openfun/marion/compare/v0.4.0-howard...v0.5.0-howard
 [0.4.0-howard]: https://github.com/openfun/marion/compare/v0.3.0-howard...v0.4.0-howard
 [0.3.0-howard]: https://github.com/openfun/marion/compare/v0.2.7-howard...v0.3.0-howard
 [0.2.7-howard]: https://github.com/openfun/marion/compare/v0.2.6-howard...v0.2.7-howard

--- a/src/howard/CHANGELOG.md
+++ b/src/howard/CHANGELOG.md
@@ -8,6 +8,10 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+
+- Enforce to use at least django-marion 0.5.0
+
 ## [0.4.0-howard] - 2022-12-21
 
 ### Changed

--- a/src/howard/setup.cfg
+++ b/src/howard/setup.cfg
@@ -23,7 +23,7 @@ classifiers =
 [options]
 include_package_data = True
 install_requires =
-  django-marion>=0.4.0
+  django-marion>=0.5.0
 packages = find:
 zip_safe = True
 

--- a/src/howard/setup.cfg
+++ b/src/howard/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = django-marion-howard
-version = 0.4.0
+version = 0.5.0
 description = FUN documents for Marion, the documents factory
 long_description = file:README.md
 long_description_content_type = text/markdown

--- a/src/marion/setup.cfg
+++ b/src/marion/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = django-marion
-version = 0.4.0
+version = 0.5.0
 description = The documents factory
 long_description = file:README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
## Purpose

Bump Marion to version 0.5.0

### Added

- Add Django 4.2 compatibility
- Add `pdf_options` argument to `AbstractDocument.create` method

Bump Howard to version 0.5.0

### Changed

- Enforce to use at least django-marion 0.5.0