### PR TITLE
🔖(minor) bump howard to 0.6.0

### DIFF
--- a/src/howard/CHANGELOG.md
+++ b/src/howard/CHANGELOG.md
@@ -6,13 +6,17 @@ The format is based on [Keep a
 Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.6.0-howard]
+
+### Changed
+
+- Enforce to use at least `django-marion` 0.6.0
 
 ## [0.5.0-howard] - 2023-05-23
 
 ### Changed
 
-- Enforce to use at least django-marion 0.5.0
+- Enforce to use at least `django-marion` 0.5.0
 
 ## [0.4.0-howard] - 2022-12-21
 
@@ -104,7 +108,8 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
 - Draft realisation certificate issuer
 
-[unreleased]: https://github.com/openfun/marion/compare/v0.5.0-howard...master
+[unreleased]: https://github.com/openfun/marion/compare/v0.6.0-howard...master
+[0.6.0-howard]: https://github.com/openfun/marion/compare/v0.5.0-howard...v0.6.0-howard
 [0.5.0-howard]: https://github.com/openfun/marion/compare/v0.4.0-howard...v0.5.0-howard
 [0.4.0-howard]: https://github.com/openfun/marion/compare/v0.3.0-howard...v0.4.0-howard
 [0.3.0-howard]: https://github.com/openfun/marion/compare/v0.2.7-howard...v0.3.0-howard

--- a/src/howard/setup.cfg
+++ b/src/howard/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = django-marion-howard
-version = 0.5.0
+version = 0.6.0
 description = FUN documents for Marion, the documents factory
 long_description = file:README.md
 long_description_content_type = text/markdown
@@ -23,7 +23,7 @@ classifiers =
 [options]
 include_package_data = True
 install_requires =
-  django-marion>=0.5.0
+  django-marion>=0.6.0
 packages = find:
 zip_safe = True
 


### PR DESCRIPTION
## [0.6.0-howard] - 2023-10-02

Changed:

- Enforce to use at least `django-marion` 0.6.0

