### PR TITLE
Bump marion & howard to 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
 ## [Unreleased]
 
+## [0.7.0] - 2023-12-13
+
+### Changed
+
+- Upgrade `Python` to 3.10
+
 ## [0.6.0] - 2023-09-19
 
 ### Added
@@ -91,7 +97,8 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 - Add `DummyDocument` example document issuer
 - Implement document issuer pattern
 
-[unreleased]: https://github.com/openfun/marion/compare/v0.6.0...master
+[unreleased]: https://github.com/openfun/marion/compare/v0.7.0...master
+[0.7.0]: https://github.com/openfun/marion/compare/v0.6.0...0.7.0
 [0.6.0]: https://github.com/openfun/marion/compare/v0.5.0...0.6.0
 [0.5.0]: https://github.com/openfun/marion/compare/v0.4.0...0.5.0
 [0.4.0]: https://github.com/openfun/marion/compare/v0.3.2...0.4.0

--- a/renovate.json
+++ b/renovate.json
@@ -5,19 +5,10 @@
     "commitMessagePrefix": "⬆️(project)",
     "commitMessageAction": "upgrade",
     "commitBodyTable": true,
-    "packageRules": [
-        {
-            "enabled": false,
-            "groupName": "ignored python dependencies",
-            "matchManagers": [
-                "setup-cfg"
-            ],
-            "matchPackageNames": [
-                "arrow",
-                "djangorestframework",
-                "pydantic",
-                "Weasyprint"
-            ]
-        }
+    "ignoreDeps": [
+        "arrow",
+        "djangorestframework",
+        "pydantic",
+        "Weasyprint"
     ]
 }

--- a/src/howard/CHANGELOG.md
+++ b/src/howard/CHANGELOG.md
@@ -6,7 +6,13 @@ The format is based on [Keep a
 Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.6.0-howard]
+## [0.7.0-howard] - 2023-12-13
+
+### Changed
+
+- Upgrade `django-marion` dependency to 0.7.0
+
+## [0.6.0-howard] - 2023-10-02
 
 ### Changed
 
@@ -108,7 +114,8 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
 - Draft realisation certificate issuer
 
-[unreleased]: https://github.com/openfun/marion/compare/v0.6.0-howard...master
+[unreleased]: https://github.com/openfun/marion/compare/v0.7.0-howard...master
+[0.7.0-howard]: https://github.com/openfun/marion/compare/v0.6.0-howard...v0.7.0-howard
 [0.6.0-howard]: https://github.com/openfun/marion/compare/v0.5.0-howard...v0.6.0-howard
 [0.5.0-howard]: https://github.com/openfun/marion/compare/v0.4.0-howard...v0.5.0-howard
 [0.4.0-howard]: https://github.com/openfun/marion/compare/v0.3.0-howard...v0.4.0-howard

--- a/src/howard/setup.cfg
+++ b/src/howard/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = django-marion-howard
-version = 0.6.0
+version = 0.7.0
 description = FUN documents for Marion, the documents factory
 long_description = file:README.md
 long_description_content_type = text/markdown
@@ -23,7 +23,7 @@ classifiers =
 [options]
 include_package_data = True
 install_requires =
-  django-marion>=0.6.0
+  django-marion==0.7.0
 packages = find:
 zip_safe = True
 

--- a/src/marion/setup.cfg
+++ b/src/marion/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = django-marion
-version = 0.6.0
+version = 0.7.0
 description = The documents factory
 long_description = file:README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
# Marion

## [0.7.0] - 2023-12-13

### Changed

- Upgrade `Python` to 3.10


# Howard

## [0.7.0-howard] - 2023-12-13

### Changed

- Upgrade `django-marion` dependency to 0.7.0
