### PR TITLE
Fix dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- `Weasyprint` 60.2+ is now needed
+
 ## [0.7.0] - 2023-12-13
 
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,12 +33,9 @@ WORKDIR /app
 RUN apt-get update && \
     apt-get install -y \
       gettext \
-      libcairo2 \
-      libffi-dev \
-      libgdk-pixbuf2.0-0 \
       libpango-1.0-0 \
-      libpangocairo-1.0-0 \
-      shared-mime-info && \
+      libpangoft2-1.0-0 \
+      pango1.0-tools && \
     rm -rf /var/lib/apt/lists/*
 
 # Copy installed python dependencies

--- a/src/marion/setup.cfg
+++ b/src/marion/setup.cfg
@@ -26,7 +26,7 @@ install_requires =
     arrow>=1.0.0
     djangorestframework>=3.12.0
     pydantic>=2.2.0
-    WeasyPrint>=59.0
+    WeasyPrint>=60.2
 packages = find:
 zip_safe = True
 


### PR DESCRIPTION
## Purpose

I noticed that footers/headers did not work in Marion. 

## Proposal

I found out that the latest versions of WeasyPrint do not use Cairo anymore.

If we follow the installation guide in their documentation, it also doesn't work because they forgot to mention `pango1.0-tools` as a dependency.

With this pull request, you will be able to use all the css rules of WeasyPrint like for example declaring the page number at the top of
each page with a css rule like:
```css
@page {
    @top-right{
        content: "Page " counter(page) " of " counter(pages);
    }
}
```